### PR TITLE
Принудительное конвертирование в кодировку CP1251

### DIFF
--- a/debug/spLibTest
+++ b/debug/spLibTest
@@ -1,6 +1,6 @@
 CREATE PROCEDURE dbo.spLibTest
 AS
 BEGIN
-    SELECT '13'
+    SELECT 'Привет всем, это русский текст!'
     SELECT 'hello'
 END

--- a/mssql/exec.c
+++ b/mssql/exec.c
@@ -18,6 +18,7 @@
 */
 
 #include "exec.h"
+#include <string.h>
 
 
 typedef struct {
@@ -30,7 +31,9 @@ exectx_t *ectx;
 
 static gboolean do_exec_sql(const char *sql, const msctx_t *ctx, GError **err)
 {
-  if ((dbcmd(ctx->dbproc, sql) == FAIL)) {
+  gchar *sqlconv = g_convert(sql, strlen(sql), "CP1251", "UTF-8",
+			     NULL, NULL, err); 
+  if ((dbcmd(ctx->dbproc, sqlconv) == FAIL)) {
     g_set_error(err, EECMD, EECMD,
 		"%d: dbcmd() failed\n", __LINE__);
     return FALSE;
@@ -47,6 +50,9 @@ static gboolean do_exec_sql(const char *sql, const msctx_t *ctx, GError **err)
 		"%d: dbresults() failed\n", __LINE__);
     return FALSE;
   }
+
+  if (sqlconv != NULL)
+    g_free(sqlconv);
 
   return TRUE;
 }

--- a/mssql/table.c
+++ b/mssql/table.c
@@ -113,7 +113,7 @@ char * make_column_def(const struct sqlfs_ms_obj *obj)
   if (!col->nullable)
     g_string_append(def, " NOT NULL");
   
-  text = g_strdup(def->str);
+  text = g_strconcat(def->str, "\n", NULL);
   g_string_free(def, TRUE);
 
   return text;
@@ -321,7 +321,7 @@ char * make_constraint_def(const struct sqlfs_ms_obj *ctrt, const char *def)
 			     ctrt->name, def);
     }
 
-  text = g_strdup(sql->str);
+  text = g_strconcat(sql->str, "\n", NULL);
   g_string_free(sql, TRUE);
   
   return text;


### PR DESCRIPTION
временное решение для обработки русских символов в хранимых процедурах;
добавлен символ перевода строки при генерации колонки и ограничений.
