### PR TITLE
Расширенные атрибуты

### DIFF
--- a/mssql/msctx.c
+++ b/mssql/msctx.c
@@ -139,11 +139,23 @@ struct sqlfs_ms_obj * find_ms_object(struct sqlfs_ms_obj *parent,
 {
   GError *terr = NULL;
   GList *list = NULL;
+  struct sqlfs_ms_obj *result = NULL;
 
   msctx_t *ctx = get_msctx(&terr);
   
   if (!parent) {
-    list = fetch_schemas(name, ctx, FALSE, &terr);
+
+    // информация по базе данных
+    if (!g_strcmp0(name, "/")) {
+      result = g_try_new0(struct sqlfs_ms_obj, 1);
+      result->name = g_strdup(name);
+      result->type = D_DB;
+    }
+    // список схем
+    else {
+      list = fetch_schemas(name, ctx, FALSE, &terr);
+    }
+    
   }
   else {
     switch (parent->type) {
@@ -161,10 +173,9 @@ struct sqlfs_ms_obj * find_ms_object(struct sqlfs_ms_obj *parent,
       break;
     }
   }
-
-  close_sql(ctx);
-
-  struct sqlfs_ms_obj *result = NULL;
+  
+  close_sql(ctx);  
+  
   if (terr != NULL)
     g_propagate_error(error, terr);
   else
@@ -172,7 +183,6 @@ struct sqlfs_ms_obj * find_ms_object(struct sqlfs_ms_obj *parent,
       result = g_list_first(list)->data;
       g_list_free(list);
     }
-      
   
   return result;
 }
@@ -613,54 +623,61 @@ GList * fetch_table_obj(int schema_id, int table_id, const char *name,
   return reslist;
 }
 
-GList * fetch_xattr_list(int major_id, int minor_id, msctx_t *ctx,
-			 GError **error)
+GList * fetch_xattr_list(int class_id, int major_id, int minor_id,
+			 msctx_t *ctx, GError **error)
 {
   GList *lst = NULL;
   GError *terr = NULL;
 
   GString *sql = g_string_new(NULL);
   g_string_append(sql, "SELECT ");
-  g_string_append(sql, " perm.[type], perm.[permission_name]");
-  g_string_append(sql, " , prin.name, perm.state_desc ");
+  g_string_append(sql, " perm.type, perm.permission_name");
+  g_string_append(sql, " , prin.name, perm.state, perm.state_desc ");
   g_string_append(sql, "FROM sys.database_permissions perm");
   g_string_append(sql, " INNER JOIN sys.database_principals prin");
   g_string_append(sql, "   ON prin.principal_id = perm.grantee_principal_id");
   g_string_append_printf(sql, " WHERE perm.major_id = %d", major_id);
   g_string_append_printf(sql, "  AND perm.minor_id = %d", minor_id);
+  g_string_append_printf(sql, "  AND perm.class = %d", class_id);
 
   if (terr == NULL)
     exec_sql_cmd(sql->str, ctx, &terr);
 
   if (!terr) {
-    char *type_buf = g_malloc0_n(dbcollen(ctx->dbproc, 1) + 1,
-				 sizeof(char ));
+    DBCHAR state_buf[2], type_buf[5];
+    
     char *perm_buf = g_malloc0_n(dbcollen(ctx->dbproc, 2) + 1,
 				 sizeof(char ));
     char *name_buf = g_malloc0_n(dbcollen(ctx->dbproc, 3) + 1,
 				 sizeof(char ));
-    char *state_buf = g_malloc0_n(dbcollen(ctx->dbproc, 4) + 1,
-				  sizeof(char ));
     
-    dbbind(ctx->dbproc, 1, STRINGBIND,
-	   dbcollen(ctx->dbproc, 1), (BYTE *) type_buf);
+    char *state_desc_buf = g_malloc0_n(dbcollen(ctx->dbproc, 5) + 1,
+				       sizeof(char ));
+    
+    dbbind(ctx->dbproc, 1, STRINGBIND, (DBINT) 0, (BYTE *) type_buf);
+    
     dbbind(ctx->dbproc, 2, STRINGBIND,
 	   dbcollen(ctx->dbproc, 2), (BYTE *) perm_buf);
     dbbind(ctx->dbproc, 3, STRINGBIND,
 	   dbcollen(ctx->dbproc, 3), (BYTE *) name_buf);
-    dbbind(ctx->dbproc, 4, STRINGBIND,
-	   dbcollen(ctx->dbproc, 4), (BYTE *) state_buf);
+
+    dbbind(ctx->dbproc, 4, STRINGBIND, (DBINT) 0, (BYTE *) state_buf);
+    
+    dbbind(ctx->dbproc, 5, STRINGBIND,
+	   dbcollen(ctx->dbproc, 5), (BYTE *) state_desc_buf);
 
     int rowcode;
+    struct sqlfs_ms_acl *acl = NULL;
     while (!terr && (rowcode = dbnextrow(ctx->dbproc)) != NO_MORE_ROWS) {
       switch(rowcode) {
       case REG_ROW:
-	struct sqlfs_ms_acl *acl = g_try_new0(struct sqlfs_ms_acl, 1);
+	acl = g_try_new0(struct sqlfs_ms_acl, 1);
 
 	acl->type = g_strdup(g_strchomp(type_buf));
 	acl->perm_name = g_strdup(g_strchomp(perm_buf));
 	acl->state = g_strdup(g_strchomp(state_buf));
-	acl->principal_name = g_strdup(name_buf);
+	acl->state_desc = g_strdup(g_strchomp(state_desc_buf));
+	acl->principal_name = g_strdup(g_strchomp(name_buf));
 	
     	lst = g_list_append(lst, acl);
 	break;
@@ -674,10 +691,10 @@ GList * fetch_xattr_list(int major_id, int minor_id, msctx_t *ctx,
 	break;
       }
     }
-    g_free(type_buf);
+    
     g_free(perm_buf);
     g_free(name_buf);
-    g_free(state_buf);
+    g_free(state_desc_buf);
   }
   
   g_string_free(sql, TRUE);

--- a/mssql/msctx.h
+++ b/mssql/msctx.h
@@ -62,6 +62,18 @@
 #define D_TEMP 0x11
 #define R_TEMP 0x99
 
+#define GRANT "G"
+#define GRANTW "W"
+#define DENY "D"
+
+
+struct sqlfs_ms_acl {
+  int state;
+  
+  char *perm;
+  char *principals;
+};
+
 struct sqlfs_ms_type {
   int sys_type_id;
   int user_type_id;
@@ -143,6 +155,8 @@ struct sqlfs_ms_obj {
     struct sqlfs_ms_type *mstype;
     struct sqlfs_ms_index *index;
     struct sqlfs_ms_constraint *clmn_ctrt;
+    
+    int is_disabled; //<! Trigger
   };
   
   char *def;

--- a/mssql/msctx.h
+++ b/mssql/msctx.h
@@ -34,6 +34,7 @@
 #define D_TT 0x04
 #define D_U 0x05
 #define D_V 0x06
+#define D_DB 0x10
 
 #define R_AF 0x20
 #define R_C 0x21
@@ -72,7 +73,7 @@ struct sqlfs_ms_acl {
   char *type;
   char *perm_name;
 
-  char *state;
+  char *state, *state_desc;
   char *principal_name;
 };
 
@@ -205,8 +206,8 @@ GList * fetch_table_obj(int schema_id, int table_id, const char *name,
 
  * Список расширенных атрибутов объекта, включая разрешения
  */
-GList * fetch_xattr_list(int major_id, int minor_id, msctx_t *ctx,
-			 GError **error);
+GList * fetch_xattr_list(int class_id, int major_id, int minor_id,
+			 msctx_t *ctx, GError **error);
 
 /*
  * Загрузить полный программный текст модуля

--- a/mssql/msctx.h
+++ b/mssql/msctx.h
@@ -64,12 +64,12 @@
 
 #define GRANT "G"
 #define GRANTW "W"
+#define REVOKE "R"
 #define DENY "D"
 
 
 struct sqlfs_ms_acl {
-  int state;
-  
+  char *state;
   char *perm;
   char *principals;
 };
@@ -195,6 +195,13 @@ GList * fetch_schema_obj(int schema_id, const char *name, msctx_t *ctx,
  */
 GList * fetch_table_obj(int schema_id, int table_id, const char *name,
 			msctx_t *ctx, GError **error);
+
+/*
+ * Список прав для объекта
+ */
+GList * fetch_acl(int class_id, int major_id, int minor_id,
+		  msctx_t *ctx, GError **error);
+
 
 /*
  * Загрузить полный программный текст модуля

--- a/mssql/msctx.h
+++ b/mssql/msctx.h
@@ -68,10 +68,11 @@
 
 
 struct sqlfs_ms_acl {
-  int state;
-  
-  char *perm;
-  char *principals;
+  char *type;
+  char *perm_name;
+
+  char *state;
+  char *principal_name;
 };
 
 struct sqlfs_ms_type {
@@ -161,6 +162,9 @@ struct sqlfs_ms_obj {
   
   char *def;
   unsigned int len;
+
+  // список разрешений struct sqlfs_ms_acl
+  GList *acls;
   
   time_t ctime;
   time_t mtime;
@@ -195,6 +199,12 @@ GList * fetch_schema_obj(int schema_id, const char *name, msctx_t *ctx,
  */
 GList * fetch_table_obj(int schema_id, int table_id, const char *name,
 			msctx_t *ctx, GError **error);
+
+/*
+ * Список расширенных атрибутов объекта, включая разрешения
+ */
+GList * fetch_xattr_list(int major_id, int minor_id, msctx_t *ctx,
+			 GError **error);
 
 /*
  * Загрузить полный программный текст модуля

--- a/mssql/mssql.c
+++ b/mssql/mssql.c
@@ -19,7 +19,9 @@
 
 #include <sqlfuse.h>
 #include <conf/keyconf.h>
+
 #include "msctx.h"
+#include "util.h"
 
 #include <string.h>
 
@@ -182,14 +184,21 @@ static struct sqlfs_ms_obj * do_find(const char *pathname, GError **error)
 
   unsigned int i = 0;
   const char *pn = g_path_skip_root(pathname);
-  if (pn == NULL)
+  char **tree = NULL;
+  if (pn == NULL || strlen(pn) < 2) {
     pn = pathname;
-
-  char **tree = g_strsplit(pn, G_DIR_SEPARATOR_S, -1);
+    tree = g_malloc0_n(2, sizeof(char *));
+    *tree = g_strdup(pn);
+  }
+  else {
+    tree = g_strsplit(pn, G_DIR_SEPARATOR_S, -1);
+  }
+  
   GString *path = g_string_new(NULL);
   
   while(*tree && !terr) {
     g_string_append_printf(path, "%s%s", G_DIR_SEPARATOR_S, *tree);
+  
     struct sqlfs_ms_obj *obj = g_hash_table_lookup(cache.db_table, path->str);
     
     if (!obj) {
@@ -270,8 +279,8 @@ static struct sqlfs_ms_obj * find_cache_obj(const char *pathname, GError **error
   }
 
   if (terr != NULL)
-    g_propagate_error(error, terr); 
-  
+    g_propagate_error(error, terr);
+
   return obj;
 }
 
@@ -1450,27 +1459,60 @@ GList * fetch_listxattr(const char *path, GError **error)
   // все объекты обладают этими атрибутами
   listx = g_list_append(listx, "user.sqlfuse.object_id");
   listx = g_list_append(listx, "user.sqlfuse.type");
+
+  int class_id = 1, major_id = 0, minor_id = 0;
+
+  if (!g_strcmp0(path, "/"))
+    class_id = 0;
   
   struct sqlfs_ms_obj *object = find_cache_obj(path, &terr);
-  int class_id = 1, minor_id = 0;
-  
-  switch(object->type) {
-  case D_SCHEMA:
-    class_id = 3;
-    break;
-  case D_V:
-    listx = g_list_append(listx, "user.sqlfuse.viewdef");
-    break;
-  case R_COL:
-    listx = g_list_append(listx, "user.sqlfuse.column_id");
-    if (object->column != NULL)
-      minor_id = object->column->column_id;
-    break;
-  case R_TR:
-    listx = g_list_append(listx, "user.sqlfuse.trigger.is_disabled");
-    break;
-  }
 
+  if (terr == NULL) {
+    major_id = object->object_id;
+    
+    switch(object->type) {
+    case D_SCHEMA:
+      class_id = 3;
+      major_id = object->schema_id;
+      break;
+    case D_V:
+      listx = g_list_append(listx, "user.sqlfuse.viewdef");
+      break;
+    case R_COL:
+      listx = g_list_append(listx, "user.sqlfuse.column_id");
+      if (object->column != NULL)
+	minor_id = object->column->column_id;
+      break;
+    case R_TR:
+      listx = g_list_append(listx, "user.sqlfuse.trigger.is_disabled");
+      break;
+    }
+
+    if (!object->acls) {
+      msctx_t *ctx = get_msctx(&terr);
+
+      //список разрешений для объекта
+      object->acls = fetch_xattr_list(class_id, major_id, minor_id,
+				      ctx, &terr);
+    
+      close_sql(ctx);
+    }
+
+    if (object->acls && terr == NULL) {
+      GList *wrk = g_list_first(object->acls);
+      struct sqlfs_ms_acl *acl = NULL;
+      while(wrk) {
+	acl = wrk->data;
+	gchar *str = g_strjoin(".", "user.sqlfuse.rights",
+			       acl->principal_name, acl->state, acl->type,
+			       NULL);
+	listx = g_list_append(listx, str);
+	wrk = g_list_next(wrk);
+      }
+    }
+    
+  }
+  
   if (terr != NULL)
     g_propagate_error(error, terr);
 
@@ -1512,6 +1554,11 @@ char * fetch_xattr(const char *path, const char *name, GError **error)
     if (!g_strcmp0(name, "user.sqlfuse.trigger.is_disabled")
 	&& object->type == R_TR) {
       res = g_strdup_printf("%d", object->is_disabled);
+    }
+
+    if (g_str_has_prefix(name, "user.sqlfuse.rights.")
+	&& object->acls) {
+      res = g_strdup_printf("%d", 1);
     }
 
   }

--- a/mssql/mssql.c
+++ b/mssql/mssql.c
@@ -1462,8 +1462,9 @@ GList * fetch_listxattr(const char *path, GError **error)
     break;
   case R_TR:
     listx = g_list_append(listx, "user.sqlfuse.trigger.is_disabled");
+    break;
   }
-  
+
   if (terr != NULL)
     g_propagate_error(error, terr);
 
@@ -1499,13 +1500,14 @@ char * fetch_xattr(const char *path, const char *name, GError **error)
     }
 
     if (!g_strcmp0(name, "user.sqlfuse.viewdef")) {
-      res = load_module_text(*schema, object, &terr);
+      res = fetch_object_text(path, &terr);
     }
 
     if (!g_strcmp0(name, "user.sqlfuse.trigger.is_disabled")
 	&& object->type == R_TR) {
       res = g_strdup_printf("%d", object->is_disabled);
     }
+
   }
   
   if (terr != NULL)

--- a/mssql/util.c
+++ b/mssql/util.c
@@ -20,17 +20,15 @@
 #include "util.h"
 
 struct cache_util {
-  GHashTable *objtypes;
+  GHashTable *objtypes, *objtypenames;
 };
 
 static struct cache_util cache;
 
 int initobjtypes()
 {
-  if (!cache.objtypes)
-    cache.objtypes = g_hash_table_new(g_str_hash, g_str_equal);
-  else
-    return 0;
+  cache.objtypes = g_hash_table_new(g_str_hash, g_str_equal);
+  cache.objtypenames = g_hash_table_new(g_direct_hash, g_direct_equal);
   
   ADD_OBJTYPE("$H", D_SCHEMA);
   ADD_OBJTYPE("$L", R_COL);
@@ -79,3 +77,8 @@ int str2mstype(char * type)
   return GPOINTER_TO_INT(r);
 }
 
+char * mstype2str(int type)
+{
+  gpointer r = g_hash_table_lookup(cache.objtypenames, GINT_TO_POINTER(type));
+  return r;
+}

--- a/mssql/util.c
+++ b/mssql/util.c
@@ -29,7 +29,8 @@ int initobjtypes()
 {
   cache.objtypes = g_hash_table_new(g_str_hash, g_str_equal);
   cache.objtypenames = g_hash_table_new(g_direct_hash, g_direct_equal);
-  
+
+  ADD_OBJTYPE("$D", D_DB);
   ADD_OBJTYPE("$H", D_SCHEMA);
   ADD_OBJTYPE("$L", R_COL);
   ADD_OBJTYPE("$T", R_TYPE);

--- a/mssql/util.h
+++ b/mssql/util.h
@@ -24,11 +24,14 @@
 #include "msctx.h"
 
 #define ADD_OBJTYPE(s,d)						\
-  g_hash_table_insert(cache.objtypes, g_strdup(s), GINT_TO_POINTER(d));
+  g_hash_table_insert(cache.objtypes, g_strdup(s), GINT_TO_POINTER(d)); \
+  g_hash_table_insert(cache.objtypenames, GINT_TO_POINTER(d), g_strdup(s));
 
 
 int initobjtypes();
 
 int str2mstype(char * type);
+
+char * mstype2str(int type);
 
 #endif

--- a/sqlfuse.h
+++ b/sqlfuse.h
@@ -133,4 +133,16 @@ void free_sqlfs_object(gpointer object);
 void destroy_cache(GError **error);
 
 
+/*
+ * Получить список доступных расширенных атрибутов для объекта
+ */
+GList * fetch_listxattr(const char *path, GError **error);
+
+
+/*
+ * Получить значение расширенного атрибута
+ */
+char * fetch_xattr(const char *path, const char *name, GError **error);
+
+
 #endif


### PR DESCRIPTION
Заявлена поддержка:
- отображение разрешений для всех монтируемых объектов #25 через расширенные атрибуты ФС;
- активация и деактивация триггеров, просмотр состояния;
- отображение определений представлений (VIEW) через расширенные атрибут `user.sqlfuse.viewdef` #33 ;
- вывод других атрибутов отображаемого объекта `user.sqlfuse.type`, `user.sqlfuse.object_id`, `user.sqlfuse.column_id`.
